### PR TITLE
Make kubediff easier to integrate with deploy.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 FROM alpine
 MAINTAINER Weaveworks Inc <help@weave.works>
+WORKDIR /
+
 RUN apk update && \
-   apk add py-yaml curl && \
+   apk add py-pip curl && \
    curl -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.2.4/bin/linux/amd64/kubectl && \
    chmod u+x /bin/kubectl
-WORKDIR /
+
+COPY . /tmp/kubediff/
+RUN pip install /tmp/kubediff/
+
 COPY prom-run kubediff /
 EXPOSE 80
 ENTRYPOINT ["/prom-run"]

--- a/kubediff
+++ b/kubediff
@@ -30,7 +30,7 @@ supply the kubeconfig for the appropriate environment.""")
     printer = JSONPrinter()
 
   failed = check_files(args, printer, options.kubeconfig)
-  if failed:
+  if failed and not options.json:
     sys.exit(2)
 
 

--- a/kubediff
+++ b/kubediff
@@ -20,6 +20,8 @@ appropriate environement.  This tools runs kubectl, so unless your
 supply the kubeconfig for the appropriate environment.""")
   parser.add_option("--kubeconfig", help="path to kubeconfig")
   parser.add_option("-j", "--json", help="output in json format", action="store_true", dest="json")
+  parser.add_option("--no-error-on-diff", help="don't exit with 2 if diff exists",
+                    action="store_false", dest="exit_on_diff", default="true")
   (options, args) = parser.parse_args()
   if len(args) == 0:
     parser.print_help()
@@ -30,7 +32,7 @@ supply the kubeconfig for the appropriate environment.""")
     printer = JSONPrinter()
 
   failed = check_files(args, printer, options.kubeconfig)
-  if failed and not options.json:
+  if failed and options.exit_on_diff:
     sys.exit(2)
 
 

--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -1,4 +1,5 @@
 from functools import partial
+import collections
 import json
 import os
 import subprocess
@@ -30,7 +31,6 @@ def different_lengths(path, want, have):
 
 missing_item = partial(Difference, "'%s' missing")
 not_equal = partial(Difference, "'%s' != '%s'")
-broken_cluster = partial(Difference, " *** %s", None)
 
 
 def diff_lists(path, want, have):
@@ -81,13 +81,13 @@ def check_file(printer, path, kubeconfig=None):
 
   kube_obj = KubeObject.from_dict(expected)
 
-  printer.add(kube_obj)
+  printer.add(path, kube_obj)
 
   try:
     running = kube_obj.get_from_cluster(kubeconfig=kubeconfig)
   except subprocess.CalledProcessError, e:
-    printer.diff(kube_obj, broken_cluster(e.output))
-    return
+    printer.diff(path, Difference(e.output, None))
+    return 0
 
   differences = 0
   for difference in diff("", expected, running):
@@ -100,7 +100,7 @@ class StdoutPrinter(object):
   def add(self, _, kube_obj):
     print "Checking %s '%s'" % (kube_obj.kind, kube_obj.namespaced_name)
 
-  def diff(self, kube_obj, difference):
+  def diff(self, _, difference):
     print " *** " + difference.to_text()
 
   def finish(self):
@@ -109,14 +109,13 @@ class StdoutPrinter(object):
 
 class JSONPrinter(object):
   def __init__(self):
-    self.data = {}
+    self.data = collections.defaultdict(list)
 
-  def add(self, kube_obj):
-    self.data.setdefault(kube_obj.kind, {}).setdefault(kube_obj.name, [])
+  def add(self, path, kube_obj):
+    pass
 
-  def diff(self, kube_obj, difference):
-    record = self.data[kube_obj.kind][kube_obj.name]
-    record.append([difference.path] + list(difference.args))
+  def diff(self, path, difference):
+    self.data[path].append(difference.to_text())
 
   def finish(self):
     print json.dumps(self.data, sort_keys=True, indent=2, separators=(',', ': '))

--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -87,7 +87,7 @@ def check_file(printer, path, kubeconfig=None):
     running = kube_obj.get_from_cluster(kubeconfig=kubeconfig)
   except subprocess.CalledProcessError, e:
     printer.diff(path, Difference(e.output, None))
-    return 0
+    return 1
 
   differences = 0
   for difference in diff("", expected, running):

--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -92,7 +92,7 @@ def check_file(printer, path, kubeconfig=None):
   differences = 0
   for difference in diff("", expected, running):
     differences += 1
-    printer.diff(kube_obj, difference)
+    printer.diff(path, difference)
   return differences
 
 

--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -97,8 +97,8 @@ def check_file(printer, path, kubeconfig=None):
 
 
 class StdoutPrinter(object):
-  def add(self, kube_obj):
-    print "Checking %s '%s'" % (kube_obj.kind, kube_obj.name)
+  def add(self, _, kube_obj):
+    print "Checking %s '%s'" % (kube_obj.kind, kube_obj.namespaced_name)
 
   def diff(self, kube_obj, difference):
     print " *** " + difference.to_text()

--- a/kubedifflib/_kube.py
+++ b/kubedifflib/_kube.py
@@ -42,6 +42,10 @@ class KubeObject(object):
     namespace = data["metadata"].get("namespace", "default")
     return cls(namespace, kind, name)
 
+  @property
+  def namespaced_name(self):
+    return "%s/%s" % (self.namespace, self.name)
+
   def get_from_cluster(self, kubeconfig=None):
     """Fetch data for this object from a Kubernetes cluster.
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+setup(
+    name='kubedifflib',
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='0.1.0',
+
+    description='Library for diffing Kubernetes configs',
+    long_description="",
+
+    # The project's main homepage.
+    url='https://github.com/weaveworks/kubediff',
+
+    # Author details
+    author='Weaveworks',
+    author_email='help@weave.works',
+
+    # Choose your license
+    license='MIT',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages=["kubedifflib"],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-# To use a consistent encoding
-from codecs import open
 from os import path
-
-here = path.abspath(path.dirname(__file__))
 
 setup(
     name='kubedifflib',
@@ -13,21 +9,12 @@ setup(
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
     version='0.1.0',
-
     description='Library for diffing Kubernetes configs',
     long_description="",
-
-    # The project's main homepage.
     url='https://github.com/weaveworks/kubediff',
-
-    # Author details
     author='Weaveworks',
     author_email='help@weave.works',
-
-    # Choose your license
     license='MIT',
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=["kubedifflib"],
+    packages=find_packages(),
+    install_requires=['PyYAML', 'attrs'],
 )


### PR DESCRIPTION
This PR makes it easier to integration with other systems (deploy).

- When using JSON output, don't use the exit value to indicate presence of diffs, so we can treat the exit code as just errors, and parse the output properly.
- Key JSON output by filename
- Make JSON output include the correct error strings
- Don't fail when file doesn't exist



