### PR TITLE
add kubediff and compare-images to path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,5 @@ setup(
     license='MIT',
     packages=find_packages(),
     install_requires=['PyYAML', 'attrs'],
+    scripts=['kubediff', 'compare-images'],
 )


### PR DESCRIPTION
It would be easier for users to pip install the repo and have access to kubediff and compare-images without having to download the source code.