### PR TITLE
Make comparison between configuration elements a bit weaker.

### DIFF
--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -53,12 +53,22 @@ def diff_dicts(path, want, have):
         yield difference
 
 
+def normalize(value):
+  if isinstance(value, int):
+    return str(value)
+  if value == [] or value == {}:
+    return None
+  return value
+
+
 def diff(path, want, have):
-  if isinstance(want, dict):
+  want = normalize(want)
+  have = normalize(have)
+  if isinstance(want, dict) and isinstance(have, dict):
     for difference in diff_dicts(path, want, have):
       yield difference
 
-  elif isinstance(want, list):
+  elif isinstance(want, list) and isinstance(have, list):
     for difference in diff_lists(path, want, have):
       yield difference
 


### PR DESCRIPTION
- Kubernetes' 'emptyDir' can be used without any attributes, allowing
  you to specify a 'None' node. When extracting the configuration from
  Kubernetes, we obtain an empty list. Normalize empty lists and
  dictionaries to 'None'.

- Kubernetes also allows you to specify numbers in the YAML as strings
  of the decimal representation. Normalize all integers to strings.