### PR TITLE
Upgrade kubectl to v1.5.5 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /
 
 RUN apk update && \
    apk add py2-pip curl make && \
-   curl -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.2.4/bin/linux/amd64/kubectl && \
+   curl -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.5.5/bin/linux/amd64/kubectl && \
    chmod u+x /bin/kubectl
 
 COPY . /tmp/kubediff/


### PR DESCRIPTION
With this commit, kubectl in Docker image is upgraded to v1.5.5 (currently latest version) from v1.2.4.
I'd like to use OIDC auth provider provided from v1.3.0 in kubediff.

- https://kubernetes.io/docs/admin/authentication/#option-1---oidc-authenticator