### PR TITLE
Ignore order when comparing lists

### DIFF
--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -45,9 +45,13 @@ def diff_lists(path, want, have):
   if not len(want) == len(have):
     yield different_lengths(path, want, have)
 
-  for i, (want_v, have_v) in enumerate(zip(want, have)):
-     for difference in diff("%s[%d]" % (path, i), want_v, have_v):
-       yield difference
+  for i, want_v in enumerate(want):
+    for j, have_v in enumerate(have):
+      if len(list(diff(None, want_v, have_v))) == 0:
+        del have[j]
+        break
+    else:
+      yield missing_item(path, "element [%d]" % i)
 
 
 def diff_dicts(path, want, have):


### PR DESCRIPTION
When patching an existing resource with `kubectl apply`, the ordering of certain lists (such as the containers in a deployment template) is not guaranteed to be preserved; this can result in spurious differences being detected as lists were compared strictly in order.

A consequence of this patch is that differences in lists are now reported at the element level e.g.

```
.spec.template.spec.containers: 'element [3]' missing
```