### PR TITLE
Use current context namespace instead of "default"

### DIFF
--- a/kubedifflib/_kube.py
+++ b/kubedifflib/_kube.py
@@ -39,7 +39,7 @@ class KubeObject(object):
     """
     kind = data["kind"]
     name = data["metadata"]["name"]
-    namespace = data["metadata"].get("namespace", "default")
+    namespace = data["metadata"].get("namespace", "")
     return cls(namespace, kind, name)
 
   @property


### PR DESCRIPTION
An object with no specified namespace in metadata defaults to current context namespace, which might be different than "default". Using "" as namespace has this effect.