### PR TITLE
Catch KeyErrors when trying to load manifest

### DIFF
--- a/kubedifflib/_images.py
+++ b/kubedifflib/_images.py
@@ -27,7 +27,10 @@ def load_config(*paths):
             continue
         with open(path, 'r') as stream:
             data = yaml.safe_load(stream)
-        kube_obj = KubeObject.from_dict(data)
+        try:
+            kube_obj = KubeObject.from_dict(data)
+        except KeyError:
+            continue
         objects[kube_obj] = data
     return objects
 


### PR DESCRIPTION
If any YAML file is not a Kubernetes object manifest file, `kubediff` fails with an exception. This PR allows for processing to continue and the YAML file is simply passed over.