### PR TITLE
Fix `make clean` step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test: $(VIRTUALENV_BIN)/py.test
 clean:
 	rm -f prom-run .uptodate $(DEPS_UPTODATE)
 	rm -rf kubedifflib.egg-info
-	find . name '*.pyc' | xargs rm -f
+	find . -name '*.pyc' | xargs rm -f
 
 clean-deps:
 	rm -rf $(VIRTUALENV_DIR)


### PR DESCRIPTION
Currently it deletes all the files in the repo (that are not directories),
including the ones in .git.