### PR TITLE
Give write() an explicit format string

### DIFF
--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -196,9 +196,7 @@ class QuietTextPrinter(object):
     else:
       self._write('## UNKNOWN')
     self._write('')
-    self._stream.write(difference.to_text())
-    self._stream.write('\n')
-    self._stream.flush()
+    self._write('%s', difference.to_text())
 
   def finish(self):
     pass


### PR DESCRIPTION
so that any `%` characters in the diff string don't confuse it.

Fixes #30 

(It had already been kludged, but I think this is clearer)