### PR TITLE
add --namespace option to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ Kubediff can be run from the command line:
       -h, --help            show this help message and exit
       --kubeconfig=KUBECONFIG
                             path to kubeconfig
+      --namespace=NAMESPACE
+                            the namespace to assume for objects where it's not
+                            specified (default = Kubernetes default for current
+                            context)
       -j, --json            output in json format
+      --no-error-on-diff    don't exit with 2 if diff exists
 
 For example:
 

--- a/kubediff
+++ b/kubediff
@@ -19,6 +19,7 @@ appropriate environment.  This tools runs kubectl, so unless your
 ~/.kube/config is configured for the correct environment, you will need to
 supply the kubeconfig for the appropriate environment.""")
   parser.add_option("--kubeconfig", help="path to kubeconfig")
+  parser.add_option("--namespace", help="the namespace to assume for objects where it's not specified", default="default")
   parser.add_option("-j", "--json", help="output in json format", action="store_true", dest="json")
   parser.add_option("--no-error-on-diff", help="don't exit with 2 if diff exists",
                     action="store_false", dest="exit_on_diff", default="true")
@@ -31,7 +32,12 @@ supply the kubeconfig for the appropriate environment.""")
   if options.json:
     printer = JSONPrinter()
 
-  failed = check_files(args, printer, options.kubeconfig)
+  config = {
+      "kubeconfig": options.kubeconfig,
+      "namespace": options.namespace
+  }
+
+  failed = check_files(args, printer, config)
   if failed and options.exit_on_diff:
     sys.exit(2)
 

--- a/kubediff
+++ b/kubediff
@@ -19,7 +19,9 @@ appropriate environment.  This tools runs kubectl, so unless your
 ~/.kube/config is configured for the correct environment, you will need to
 supply the kubeconfig for the appropriate environment.""")
   parser.add_option("--kubeconfig", help="path to kubeconfig")
-  parser.add_option("--namespace", help="the namespace to assume for objects where it's not specified", default="default")
+  parser.add_option("--namespace",
+                    help="the namespace to assume for objects where it's not specified (default = Kubernetes default for current context)",
+                    default="")
   parser.add_option("-j", "--json", help="output in json format", action="store_true", dest="json")
   parser.add_option("--no-error-on-diff", help="don't exit with 2 if diff exists",
                     action="store_false", dest="exit_on_diff", default="true")

--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -132,13 +132,12 @@ def diff(path, want, have):
     yield not_equal(path, want, have)
 
 
-def check_file(printer, path, kubeconfig=None):
+def check_file(printer, path, config):
   """Check YAML file 'path' for differences.
 
   :param printer: Where we report differences to.
   :param str path: The YAML file to test.
-  :param str kubeconfig: Path to a Kubernetes configuration file.
-      If None, we use the default.
+  :param dict config: Contains Kubernetes parsing and access configuration.
   :return: Number of differences found.
   """
   with open(path, 'r') as stream:
@@ -146,12 +145,12 @@ def check_file(printer, path, kubeconfig=None):
 
     differences = 0
     for data in expected:
-      kube_obj = KubeObject.from_dict(data)
+      kube_obj = KubeObject.from_dict(data, config["namespace"])
 
       printer.add(path, kube_obj)
 
       try:
-        running = kube_obj.get_from_cluster(kubeconfig=kubeconfig)
+        running = kube_obj.get_from_cluster(config["kubeconfig"])
       except subprocess.CalledProcessError, e:
         printer.diff(path, Difference(e.output, None))
         differences += 1
@@ -218,12 +217,11 @@ class JSONPrinter(object):
     print json.dumps(self.data, sort_keys=True, indent=2, separators=(',', ': '))
 
 
-def check_files(paths, printer, kubeconfig=None):
+def check_files(paths, printer, config):
   """Check all files in 'paths' for differences to a Kubernetes cluster.
 
   :param printer: Where differences are reported to as they are found.
-  :param str kubeconfig: Path to a kubeconfig file for the cluster to diff
-      against.
+  :param dict config: Contains Kubernetes parsing and access configuration.
   :return: True if there are differences, False otherwise.
   """
   differences = 0
@@ -231,7 +229,7 @@ def check_files(paths, printer, kubeconfig=None):
     _, extension = os.path.splitext(path)
     if extension not in [".yaml", ".yml"]:
       continue
-    differences += check_file(printer, path, kubeconfig=kubeconfig)
+    differences += check_file(printer, path, config)
 
   printer.finish()
   return bool(differences)

--- a/kubedifflib/_kube.py
+++ b/kubedifflib/_kube.py
@@ -31,15 +31,16 @@ class KubeObject(object):
   name = attr.ib()
 
   @classmethod
-  def from_dict(cls, data):
+  def from_dict(cls, data, namespace=""):
     """Construct a 'KubeObject' from a dictionary of Kubernetes data.
 
-    'data' might be obtained from a Kubernetes cluster, or decoded from a YAML
-    config file.
+    :param dict data: Kubernetes object data; might be obtained from a Kubernetes cluster,
+        or decoded from a YAML config file.
+    :param str namespace: the namespace to use if it's not defined in the object definition
     """
     kind = data["kind"]
     name = data["metadata"]["name"]
-    namespace = data["metadata"].get("namespace", "")
+    namespace = data["metadata"].get("namespace", namespace)
     return cls(namespace, kind, name)
 
   @property


### PR DESCRIPTION
This is a rebased version of #46 from @foben, fixed up to use the default namespace for the context if otherwise unspecified.  (This lets us accommodate the intention of #44)
