### PR TITLE
Add org.opencontainers.image.* labels to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM alpine:3.5
-MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 
 RUN apk update && \
@@ -14,3 +13,10 @@ RUN pip install -r /tmp/kubediff/requirements.txt
 COPY prom-run kubediff compare-images /
 EXPOSE 80
 ENTRYPOINT ["/prom-run"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="kubediff" \
+      org.opencontainers.image.source="https://github.com/weaveworks/kubediff" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 all: .uptodate lint test
 
 IMAGE_VERSION := $(shell ./tools/image-tag)
+GIT_REVISION := $(shell git rev-parse HEAD)
 
 # Python-specific stuff
 VIRTUALENV_DIR ?= .env
@@ -41,7 +42,7 @@ deps: $(DEPS_UPTODATE)
 $(VIRTUALENV_BIN)/flake8 $(VIRTUALENV_BIN)/py.test: $(DEPS_UPTODATE)
 
 .uptodate: prom-run Dockerfile
-	docker build -t weaveworks/kubediff .
+	docker build --build-arg=revision=$(GIT_REVISION) -t weaveworks/kubediff .
 	docker tag weaveworks/kubediff:latest weaveworks/kubediff:$(IMAGE_VERSION)
 	docker tag weaveworks/kubediff:$(IMAGE_VERSION) quay.io/weaveworks/kubediff:$(IMAGE_VERSION)
 	docker tag weaveworks/kubediff:latest quay.io/weaveworks/kubediff:latest


### PR DESCRIPTION
Why? What?

- This should ultimately help for image-to-code back references.
- `org.label-schema.*` labels are now deprecated, in favour of `org.opencontainers.image.*` labels.
  See also: https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema
- `MAINTAINER` is deprecated, in favour of the `maintainer` label.
- Git revision (`git rev-parse HEAD`) is now injected at `docker build` time.

Testing

```console
$ docker inspect weaveworks/kubediff
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "10e0c78f86b9f63a5a66435d49c66348e215be06",
                "org.opencontainers.image.source": "https://github.com/weaveworks/kubediff",
                "org.opencontainers.image.title": "kubediff",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]
```
