### PR TITLE
Skip yaml document if it's empty

### DIFF
--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -145,6 +145,8 @@ def check_file(printer, path, config):
 
     differences = 0
     for data in expected:
+      if data is None:
+        continue
       kube_obj = KubeObject.from_dict(data, config["namespace"])
 
       printer.add(path, kube_obj)


### PR DESCRIPTION
I'm trying to `kubediff` the changes between the output of `helm template` and the running helm release.

In some cases, `helm template` can generate empty yaml documents, which are not handled by kubediff.