### PR TITLE
Include future in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 attrs
 pyyaml
 tabulate
+future


### PR DESCRIPTION
`future` is used by `kubedifflib/_diff.py`