### PR TITLE
Ignore empty yaml documents when parsing file

### DIFF
--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -151,6 +151,9 @@ def check_file(printer, path, config):
 
     differences = 0
     for data in expected:
+      # data can be None, e.g. in cases where the doc ends with a '---'
+      if not data:
+        continue
       try:
         for kube_obj in KubeObject.from_dict(data, config["namespace"]):
           printer.add(path, kube_obj)


### PR DESCRIPTION
The `yaml.load_all` function may return None as an element if the file ends with a yaml separator (`---`) as shown below. This PR changes the diff to ignore such invalid documents.

```
>>> import yaml
>>> list(yaml.load_all('''a: b
... ---
... '''))
[{'a': 'b'}, None]
```

Before this change the following error would be triggered by a yaml file ending with `---`:

```
Traceback (most recent call last):
  File "/kubediff", line 48, in <module>
    main()
  File "/kubediff", line 42, in main
    failed = check_files(args, printer, config)
  File "/usr/lib/python2.7/site-packages/kubedifflib/_diff.py", line 239, in check_files
    differences += check_file(printer, path, config)
  File "/usr/lib/python2.7/site-packages/kubedifflib/_diff.py", line 155, in check_file
    for kube_obj in KubeObject.from_dict(data, config["namespace"]):
  File "/usr/lib/python2.7/site-packages/kubedifflib/_kube.py", line 43, in from_dict
    kind = data["kind"]
TypeError: 'NoneType' object has no attribute '__getitem__'
```