### PR TITLE
Run tests before building container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean lint test clean-deps deps
 .DEFAULT_GOAL := all
 
-all: .uptodate lint test
+all: test lint .uptodate
 
 IMAGE_VERSION := $(shell ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse HEAD)


### PR DESCRIPTION
This seems a more logical ordering to me - find out if the tests pass before checking the style of the code before building the container.
