### PR TITLE
Use safe_load() to read yaml

### DIFF
--- a/kubedifflib/_images.py
+++ b/kubedifflib/_images.py
@@ -28,7 +28,7 @@ def load_config(*paths):
     if extension not in [".yaml", ".yml"]:
       continue
     with open(path, 'r') as stream:
-      data = yaml.load(stream)
+      data = yaml.safe_load(stream)
     kube_obj = KubeObject.from_dict(data)
     objects[kube_obj] = data
   return objects

--- a/kubedifflib/_kube.py
+++ b/kubedifflib/_kube.py
@@ -75,4 +75,4 @@ class KubeObject(object):
       args.append("--kubeconfig=%s" % kubeconfig)
 
     running = subprocess.check_output(["kubectl", "get"] + args + [self.kind, self.name], stderr=subprocess.STDOUT)
-    return yaml.load(running)
+    return yaml.safe_load(running)


### PR DESCRIPTION
Since we only read low-level objects like string and dict, we don't need the more advanced capabilities of load() which (as of pyyaml 5.1) generate a warning.

Fixes #87 
