### PR TITLE
Add --context parameter for easier switch between kubeconfig context

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Kubediff can be run from the command line:
       -h, --help            show this help message and exit
       --kubeconfig=KUBECONFIG
                             path to kubeconfig
+      --context=CONTEXT     name of kubeconfig context to use
       --namespace=NAMESPACE
                             the namespace to assume for objects where it's not
                             specified (default = Kubernetes default for current

--- a/kubediff
+++ b/kubediff
@@ -19,6 +19,7 @@ appropriate environment.  This tools runs kubectl, so unless your
 ~/.kube/config is configured for the correct environment, you will need to
 supply the kubeconfig for the appropriate environment.""")
   parser.add_option("--kubeconfig", help="path to kubeconfig")
+  parser.add_option("--context", help="name of kubeconfig context to use")
   parser.add_option("--namespace",
                     help="the namespace to assume for objects where it's not specified (default = Kubernetes default for current context)",
                     default="")
@@ -36,7 +37,8 @@ supply the kubeconfig for the appropriate environment.""")
 
   config = {
       "kubeconfig": options.kubeconfig,
-      "namespace": options.namespace
+      "namespace": options.namespace,
+      "context": options.context
   }
 
   failed = check_files(args, printer, config)

--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -169,7 +169,7 @@ def check_file(printer, path, config):
           printer.add(path, kube_obj)
 
           try:
-            running = kube_obj.get_from_cluster(config["kubeconfig"])
+            running = kube_obj.get_from_cluster(config["kubeconfig"], config["context"])
           except subprocess.CalledProcessError as e:
             printer.diff(path, Difference(e.output, None))
             differences += 1

--- a/kubedifflib/_kube.py
+++ b/kubedifflib/_kube.py
@@ -63,7 +63,7 @@ class KubeObject(object):
   def namespaced_name(self):
     return "%s/%s" % (self.namespace, self.name)
 
-  def get_from_cluster(self, kubeconfig=None):
+  def get_from_cluster(self, kubeconfig=None, context=None):
     """Fetch data for this object from a Kubernetes cluster.
 
     :param str kubeconfig: Path to a Kubernetes configuration file. If None,
@@ -73,6 +73,8 @@ class KubeObject(object):
     args = ["--namespace=%s" % self.namespace, "-o=yaml"]
     if kubeconfig is not None:
       args.append("--kubeconfig=%s" % kubeconfig)
+    if context is not None:
+      args.append("--context=%s" % context)
 
     running = subprocess.check_output(["kubectl", "get"] + args + [self.kind, self.name], stderr=subprocess.STDOUT)
     return yaml.safe_load(running)


### PR DESCRIPTION
At my org we work with several clusters in parallel, each in their own Kubeconfig context. Some of our admins are used to passing the `--context` param to `kubectl`. Being able to specify the context as a parameter to kubeconfig would be a big timesaver for them.

The parameter is simply sent through to `kubectl`, not much logic here, works essentially like `--kubeconfig`.