### PR TITLE
adding more information to show when element is missing

### DIFF
--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -84,8 +84,8 @@ def diff_lists(path, want, have):
   def eq(x, y):
     return len(list(diff('', x, y))) == 0
 
-  for i in list_subtract(want, have, eq):
-    yield missing_item(path, "element [%d]" % i)
+  for (i,x) in list_subtract(want, have, eq):
+    yield missing_item(path, "element [%d] => %s" % (i,x))
 
 
 def list_subtract(xs, ys, equality=operator.eq):
@@ -99,7 +99,7 @@ def list_subtract(xs, ys, equality=operator.eq):
         matched.add(j)
         break
     else:
-      yield i
+      yield (i,x)
 
 
 def diff_dicts(path, want, have):


### PR DESCRIPTION
Elements that are reported missing are only shown with their index which is not informative since YAML doesn't enforce indexing. I find it useful to actually print the content of the missing element like this:

```
.spec.template.spec.volumes: 'element [0] => {'hostPath': {'path': '/'}, 'name': 'hostroot'}' missing
## zaml-xxx/zaml-xxx (Deployment.v1.apps)
```

Luckily the information is already there in the structure, I'm simply returning a tuple of the element path with value and passing it along.