### PR TITLE
Context attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Kubediff can be run from the command line:
 
     Options:
       -h, --help            show this help message and exit
+      --context=CONTEXT
+                            name of context (defaults to current-context if not specified)
       --kubeconfig=KUBECONFIG
                             path to kubeconfig
       --namespace=NAMESPACE

--- a/kubediff
+++ b/kubediff
@@ -19,6 +19,7 @@ appropriate environment.  This tools runs kubectl, so unless your
 ~/.kube/config is configured for the correct environment, you will need to
 supply the kubeconfig for the appropriate environment.""")
   parser.add_option("--kubeconfig", help="path to kubeconfig")
+  parser.add_option("--context", help="name of the context, will use current-context in kubeconfig if not specified")
   parser.add_option("--namespace",
                     help="the namespace to assume for objects where it's not specified (default = Kubernetes default for current context)",
                     default="")
@@ -36,7 +37,8 @@ supply the kubeconfig for the appropriate environment.""")
 
   config = {
       "kubeconfig": options.kubeconfig,
-      "namespace": options.namespace
+      "namespace": options.namespace,
+      "context": options.context
   }
 
   failed = check_files(args, printer, config)

--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -84,8 +84,8 @@ def diff_lists(path, want, have):
   def eq(x, y):
     return len(list(diff('', x, y))) == 0
 
-  for i in list_subtract(want, have, eq):
-    yield missing_item(path, "element [%d]" % i)
+  for (i,x) in list_subtract(want, have, eq):
+    yield missing_item(path, "element [%d] => %s" % (i,x))
 
 
 def list_subtract(xs, ys, equality=operator.eq):
@@ -99,7 +99,7 @@ def list_subtract(xs, ys, equality=operator.eq):
         matched.add(j)
         break
     else:
-      yield i
+      yield (i,x)
 
 
 def diff_dicts(path, want, have):

--- a/kubedifflib/_diff.py
+++ b/kubedifflib/_diff.py
@@ -169,7 +169,7 @@ def check_file(printer, path, config):
           printer.add(path, kube_obj)
 
           try:
-            running = kube_obj.get_from_cluster(config["kubeconfig"])
+            running = kube_obj.get_from_cluster(config["context"],config["kubeconfig"])
           except subprocess.CalledProcessError as e:
             printer.diff(path, Difference(e.output, None))
             differences += 1


### PR DESCRIPTION
I operate several clusters and find it very useful to specify the exact context name when running kubectl, I noticed that kubediff doesn't allow that, so I've enabled it.