### PR TITLE
Fix yaml parsing for list obj

### DIFF
--- a/kubedifflib/_kube.py
+++ b/kubedifflib/_kube.py
@@ -41,7 +41,7 @@ class KubeObject(object):
     :param str namespace: the namespace to use if it's not defined in the object definition
     """
     kind = data["kind"]
-    if kind.lower() == "list":
+    if kind.lower().endswith("list"):
       for obj in data["items"]:
         for kube_obj in KubeObject.from_dict(obj, namespace=namespace):
           yield kube_obj


### PR DESCRIPTION
A quick fix for #96, as documented [here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds):

> The name of a list kind must end with "List". Lists have a limited set of common metadata. All lists use the required "items" field to contain the array of objects they return. Any kind that has the "items" field must be a list kind.

Equality test is not enough here,  types like `RoleBindingList` and `RoleList` will fail.