### PR TITLE
Move main kubediff to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,33 @@ running configuration and your version controlled configuration.
 Kubediff can be run from the command line:
 
     $ ./kubediff
-    Usage: kubediff [options] <dir/file>...
+    usage: kubediff [-h] [--kubeconfig KUBECONFIG] [--context CONTEXT] [--namespace NAMESPACE] [--json] [--no-error-on-diff] [paths ...]
 
-    Compare yaml files in <dir> to running state in kubernetes and print the
-    differences.  This is useful to ensure you have applied all your changes to the
-    appropriate environment.  This tools runs kubectl, so unless your
-    ~/.kube/config is configured for the correct environment, you will need to
-    supply the kubeconfig for the appropriate environment.
+         _          _             _  _   __   __
+        | |__ _  _ | |__  ___  __| |(_) / _| / _|
+        | / /| || || '_ \/ -_)/ _` || ||  _||  _|
+        |_\_\ \_,_||_.__/\___|\__,_||_||_|  |_|
 
-    Options:
+        Compare yaml files in path(s) to running state in kubernetes and print the
+        differences. This is useful to ensure you have applied all your changes
+        to the appropriate environment. This tools runs kubectl, so unless your
+        ~/.kube/config is configured for the correct environment, you will need
+        to supply the kubeconfig for the appropriate environment.
+
+    positional arguments:
+      paths                  path(s) from which kubediff will look for configuration files
+
+    optional arguments:
       -h, --help            show this help message and exit
-      --kubeconfig=KUBECONFIG
+      --kubeconfig KUBECONFIG, -k KUBECONFIG
                             path to kubeconfig
-      --context=CONTEXT     name of kubeconfig context to use
-      --namespace=NAMESPACE
-                            the namespace to assume for objects where it's not
-                            specified (default = Kubernetes default for current
-                            context)
-      -j, --json            output in json format
-      --no-error-on-diff    don't exit with 2 if diff exists
+      --context CONTEXT, -c CONTEXT
+                            name of kubeconfig context to use
+      --namespace NAMESPACE, -n NAMESPACE
+                            Namespace to assume for objects where it is not specified (default = Kubernetes default for current context)
+      --json, -j            output in json format
+      --no-error-on-diff, -e
+                            don't exit with 2 if diff exists
 
 For example:
 
@@ -60,9 +68,9 @@ the service:
     secret "kubediff-secret" created
     service "kubediff" created
 
-And to view the UI, run the follow command and go to http://localhost:4040
+And to view the UI, run the follow command and go to [http://localhost:4040](http://localhost:4040)
 
-    $ kubectl port-forward $(kubectl get pod --selector=name=kubediff -o jsonpath={.items..metadata.name}) 4040:80
+    `$ kubectl port-forward $(kubectl get pod --selector=name=kubediff -o jsonpath={.items..metadata.name}) 4040:80`
 
 ![Kubediff Screenshot](/imgs/screenshot.png)
 
@@ -87,29 +95,25 @@ These alerts can be sent to Slack, for example:
 To quickly see how two sets of configurations differ, purely in terms of
 images:
 
-```
-$ ./compare-images ../service-conf/k8s/dev/ ../service-conf/k8s/prod/
-Image                          dev                   prod
------------------------------  --------------------  --------------------
-quay.io/weaveworks/grafana     master-0fc7cc2        master-08fd09d
-quay.io/weaveworks/prometheus  master-0fc7cc2        master-4fb2aed
-quay.io/weaveworks/ui-server   master-2899c36        master-45d67b3
-tomwilkie/prometheus           frankenstein-8a5ec1b  frankenstein-ebe5808
-weaveworks/scope               master-1a1021c        master-14d0e4e
-```
+    $ ./compare-images ../service-conf/k8s/dev/ ../service-conf/k8s/prod/
+    Image                          dev                   prod
+    -----------------------------  --------------------  --------------------
+    quay.io/weaveworks/grafana     master-0fc7cc2        master-08fd09d
+    quay.io/weaveworks/prometheus  master-0fc7cc2        master-4fb2aed
+    quay.io/weaveworks/ui-server   master-2899c36        master-45d67b3
+    tomwilkie/prometheus           frankenstein-8a5ec1b  frankenstein-ebe5808
+    weaveworks/scope               master-1a1021c        master-14d0e4e
 
 ## Build
 
-```
-mkdir -p $GOPATH/src/github.com/prometheus && cd "$_"
-git clone git@github.com:prometheus/client_golang.git
-mkdir -p $GOPATH/src/github.com/weaveworks && cd "$_"
-git clone git@github.com:weaveworks/kubediff.git
-cd kubediff
-make
-```
+    mkdir -p $GOPATH/src/github.com/prometheus && cd "$_"
+    git clone git@github.com:prometheus/client_golang.git
+    mkdir -p $GOPATH/src/github.com/weaveworks && cd "$_"
+    git clone git@github.com:weaveworks/kubediff.git
+    cd kubediff
+    make
 
-## <a name="help"></a>Getting Help
+## Getting Help
 
 If you have any questions about, feedback for or problems with `kubediff`:
 

--- a/kubediff
+++ b/kubediff
@@ -1,50 +1,99 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-import optparse
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
+import argparse
 import sys
 
 from kubedifflib import (
-  check_files,
-  JSONPrinter,
-  QuietTextPrinter,
+    check_files,
+    JSONPrinter,
+    QuietTextPrinter,
 )
 
 
+class ParseArgs():
+    def __init__(self):
+
+        # Parse arguments passed at cli
+        self.parse_arguments()
+
+    def parse_arguments(self):
+
+        description = '''
+     _          _             _  _   __   __
+    | |__ _  _ | |__  ___  __| |(_) / _| / _|
+    | / /| || || '_ \\/ -_)/ _` || ||  _||  _|
+    |_\\_\\ \\_,_||_.__/\\___|\\__,_||_||_|  |_|
+
+    Compare yaml files in path(s) to running state in kubernetes and print the
+    differences. This is useful to ensure you have applied all your changes
+    to the appropriate environment. This tools runs kubectl, so unless your
+    ~/.kube/config is configured for the correct environment, you will need
+    to supply the kubeconfig for the appropriate environment.'''
+
+        parser = argparse.ArgumentParser(description=description,
+                                         formatter_class=argparse.RawTextHelpFormatter)
+
+        parser.add_argument('--kubeconfig',
+                            '-k',
+                            help='path to kubeconfig')
+
+        parser.add_argument('--context',
+                            '-c',
+                            help='name of kubeconfig context to use')
+
+        parser.add_argument('--namespace',
+                            '-n',
+                            help=('Namespace to assume for objects where it is not '
+                                  'specified (default = Kubernetes default for '
+                                  'current context)'),
+                            default='default')
+
+        parser.add_argument('--json',
+                            '-j',
+                            help='output in json format',
+                            action='store_true',
+                            dest='json')
+
+        parser.add_argument('--no-error-on-diff',
+                            '-e',
+                            help='don\'t exit with 2 if diff exists',
+                            action='store_false',
+                            dest='exit_on_diff',
+                            default=True)
+
+        parser.add_argument('paths', nargs='*', help='path(s) from which '
+                            'kubediff will look for configuration files')
+
+        self.args = parser.parse_args()
+
+        if len(self.args.paths) == 0:
+            parser.print_help()
+            sys.exit(1)
+
+
 def main():
-  parser = optparse.OptionParser("""usage: %prog [options] <dir/file>...
 
-Compare yaml files in <dir> to running state in kubernetes and print the
-differences.  This is useful to ensure you have applied all your changes to the
-appropriate environment.  This tools runs kubectl, so unless your
-~/.kube/config is configured for the correct environment, you will need to
-supply the kubeconfig for the appropriate environment.""")
-  parser.add_option("--kubeconfig", help="path to kubeconfig")
-  parser.add_option("--context", help="name of kubeconfig context to use")
-  parser.add_option("--namespace",
-                    help="the namespace to assume for objects where it's not specified (default = Kubernetes default for current context)",
-                    default="")
-  parser.add_option("-j", "--json", help="output in json format", action="store_true", dest="json")
-  parser.add_option("--no-error-on-diff", help="don't exit with 2 if diff exists",
-                    action="store_false", dest="exit_on_diff", default="true")
-  (options, args) = parser.parse_args()
-  if len(args) == 0:
-    parser.print_help()
-    sys.exit(1)
+    options = ParseArgs()
+    print(options.args)
 
-  printer = QuietTextPrinter()
-  if options.json:
-    printer = JSONPrinter()
+    printer = QuietTextPrinter()
+    if options.args.json:
+        printer = JSONPrinter()
 
-  config = {
-      "kubeconfig": options.kubeconfig,
-      "namespace": options.namespace,
-      "context": options.context
-  }
+    config = {
+        "kubeconfig": options.args.kubeconfig,
+        "namespace": options.args.namespace,
+        "context": options.args.context
+    }
 
-  failed = check_files(args, printer, config)
-  if failed and options.exit_on_diff:
-    sys.exit(2)
+    failed = check_files(options.args.paths, printer, config)
+    if failed and options.args.exit_on_diff:
+        sys.exit(2)
 
 
 if __name__ == '__main__':
-  main()
+    main()


### PR DESCRIPTION
First small change that will start to give some new air to the Python3 Migration. Now it is using argparse instead orgparse (deprecated) with format and a main Class for the args.

Related to #103